### PR TITLE
Minor fix for editor 

### DIFF
--- a/src/blocks/accordion/editor.scss
+++ b/src/blocks/accordion/editor.scss
@@ -2,6 +2,10 @@
  * Editor-specific styles for accordion block
  */
 .wp-block-pikari-gutenberg-accordion {
+	.pikari-gutenberg-accordion-heading.is-highlighted::after {
+		position: relative;
+	}
+
 	// Visual feedback in editor
 	.wp-block-pikari-gutenberg-accordion-item {
 		cursor: pointer;


### PR DESCRIPTION
This fixes the issue when hovering over the heading block, the icon would shift